### PR TITLE
feat: support glob as files key

### DIFF
--- a/models_test.ts
+++ b/models_test.ts
@@ -147,6 +147,7 @@ Deno.test("VersionInfo.bumpSummary()", () => {
     commit: "chore: hey %.%.%",
     files: {
       "README.md": ["v%.%.%", "@%.%.%"],
+      "testdata/*/importMap.json": ["v%.%.%"],
       "main.ts": [`"%.%.%"`],
     },
   });
@@ -161,6 +162,8 @@ Updating version:
 Version patterns:
   README.md: ${green("v1.2.3 => v1.3.0")}
   README.md: ${green("@1.2.3 => @1.3.0")}
+  testdata/one/importMap.json: ${green("v1.2.3 => v1.3.0")}
+  testdata/two/importMap.json: ${green("v1.2.3 => v1.3.0")}
   main.ts: ${green('"1.2.3" => "1.3.0"')}
   `.trim(),
   );

--- a/testdata/one/importMap.json
+++ b/testdata/one/importMap.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "one": "https://deno.land/x/one@v1.2.3"
+  }
+}

--- a/testdata/two/importMap.json
+++ b/testdata/two/importMap.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "two": "https://deno.land/x/two@v1.2.3"
+  }
+}


### PR DESCRIPTION
I have a need to update the version in a lot of files. This PR allows the keys of files within the config to be a glob pattern.

```yaml
version: 0.0.0
commit: 'chore: bump version to %.%.%'
files:
  README.md: v%.%.%
  examples/*/importMap.json: v%.%.%
```