### PR TITLE
Add --no-tag commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ files:
 - `version` is the current version of your repository. You need to set this to
   the actuall current version number.
 - `commit` is the commit message which is used when you perform the command
-  `bmp -c`, which commits the change, and cut the tag. This field is optional,
-  and you can delete this if you don't want to use committing feature.
+  `bmp -c`, which commits the change, and cuts the tag by default. This field is
+  optional, and you can delete this if you don't want to use committing feature.
 - `files` contains the version number patterns in files. For example, if your
   README.md file contains `my-library v1.2.3`, then you need to set this
   property to `README.md: my-library v%.%.%`. (As you can see `%.%.%` part
@@ -102,13 +102,17 @@ config.
 ## `bmp -c`
 
 Commits the current change in the git repository with the commit message
-specified in .bmp.yml config and cut the tag.
+specified in .bmp.yml config and cuts the tag.
+
+Add `--no-tag` to commit without creating a tag.
 
 ## `bmp -pc`
 
 Patch version up, commits the change, and cut the tag.
 
 Also `bmp -mc` for minor, `bmp -jc` for major.
+
+Use `bmp -pc --no-tag` to skip creating the tag.
 
 # LICENSE
 

--- a/cli.ts
+++ b/cli.ts
@@ -20,6 +20,7 @@ Options:
   -j, --major        Bumps major (1.0.0) level
   --preid <label>    Sets the pre-release version id (e.g. alpha, beta.1)
   -r, --release      Removes the pre-release version id
+  --no-tag           Skips creating a git tag when used with --commit
   -h, --help         Shows this help and exit
   -v, --version      Shows the version of this command and exit
 `);
@@ -35,6 +36,7 @@ export async function main(args: string[]): Promise<number> {
     major,
     preid,
     release,
+    "no-tag": noTag,
     help,
     version,
   } = parseArgs(args, {
@@ -48,6 +50,7 @@ export async function main(args: string[]): Promise<number> {
       "release",
       "info",
       "init",
+      "no-tag",
     ],
     string: ["preid"],
     alias: {
@@ -117,7 +120,7 @@ export async function main(args: string[]): Promise<number> {
   }
 
   if (commit) {
-    await performCommit(versionInfo);
+    await performCommit(versionInfo, { tag: !noTag });
   } else if (!versionInfo.isUpdated()) {
     console.log(versionInfo.toString());
   }

--- a/cli_test.ts
+++ b/cli_test.ts
@@ -11,6 +11,7 @@ Deno.test("cli --help", async () => {
 
   assertEquals(code, 0);
   assertStringIncludes(decoder.decode(stdout), "Usage:");
+  assertStringIncludes(decoder.decode(stdout), "--no-tag");
 });
 
 Deno.test("cli --version", async () => {

--- a/perform_commit.ts
+++ b/perform_commit.ts
@@ -1,29 +1,36 @@
 import { green } from "@std/fmt/colors";
 import type { VersionInfo } from "./models.ts";
 
-export async function performCommit(info: VersionInfo) {
+type GitRunner = (args: string[]) => Promise<void>;
+
+export interface PerformCommitOptions {
+  tag?: boolean;
+  runGit?: GitRunner;
+}
+
+async function runGitCommand(args: string[]) {
+  const p = new Deno.Command("git", {
+    args,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  await p.output();
+}
+
+export async function performCommit(
+  info: VersionInfo,
+  { tag = true, runGit = runGitCommand }: PerformCommitOptions = {},
+) {
   console.log("====> Executing git commands");
   console.log(green(`git add .`));
-  const p0 = new Deno.Command("git", {
-    args: ["add", "."],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  await p0.output();
+  await runGit(["add", "."]);
   const m = info.getCommitMessage();
   console.log(green(`git commit -m "${m}"`));
-  const p1 = new Deno.Command("git", {
-    args: ["commit", "-m", m],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  await p1.output();
+  await runGit(["commit", "-m", m]);
+  if (!tag) {
+    return;
+  }
   const t = info.getTag();
   console.log(green(`git tag ${t}`));
-  const p2 = new Deno.Command("git", {
-    args: ["tag", t],
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  await p2.output();
+  await runGit(["tag", t]);
 }

--- a/perform_commit_test.ts
+++ b/perform_commit_test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "@std/assert";
+
+import { performCommit } from "./perform_commit.ts";
+import { VersionInfo } from "./models.ts";
+
+function createVersionInfo() {
+  return VersionInfo.create({
+    version: "1.2.3",
+    commit: "chore: bump to %.%.%",
+    files: {
+      "README.md": "v%.%.%",
+    },
+  });
+}
+
+Deno.test("performCommit - commits and creates tag by default", async () => {
+  const commands: string[][] = [];
+
+  await performCommit(createVersionInfo(), {
+    runGit: (args) => {
+      commands.push(args);
+      return Promise.resolve();
+    },
+  });
+
+  assertEquals(commands, [
+    ["add", "."],
+    ["commit", "-m", "chore: bump to 1.2.3"],
+    ["tag", "1.2.3"],
+  ]);
+});
+
+Deno.test("performCommit - skips tag when disabled", async () => {
+  const commands: string[][] = [];
+
+  await performCommit(createVersionInfo(), {
+    tag: false,
+    runGit: (args) => {
+      commands.push(args);
+      return Promise.resolve();
+    },
+  });
+
+  assertEquals(commands, [
+    ["add", "."],
+    ["commit", "-m", "chore: bump to 1.2.3"],
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a --no-tag option for commit flows
- keep existing -c behavior creating tags by default
- document the new option and cover tag/no-tag commit behavior with tests

## Tests
- mise x deno@2.7.4 -- deno fmt --check
- mise x deno@2.7.4 -- deno lint
- mise x deno@2.7.4 -- deno test -A